### PR TITLE
Use consistent labelColor in "Variations" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ We recommend using a message you're comfortable with - it's more important to
 have your support than to use one of our messages.
 
 To use your own custom badge, you can use the following code, inserting your own
-message and alt text.
+message and alt text. The `color` and `labelColor` parameters are also
+customizable.
 
 ```
-![ADD ALT TEXT HERE](https://img.shields.io/badge/YOUR_MESSAGE_HERE-%F0%9F%87%B5%F0%9F%87%B8%20Tech_For_Palestine-D83838?labelColor=01B861&color=D83838&link=https%3A%2F%2Ftechforpalestine.org%2Flearn-more)
+![ADD ALT TEXT HERE](https://img.shields.io/badge/%F0%9F%87%B5%F0%9F%87%B8_YOUR_MESSAGE_HERE-techforpalestine.org-000?labelColor=grey&color=D83838&link=https%3A%2F%2Ftechforpalestine.org%2Flearn-more)
 ```
 
 ![ADD ALT TEXT HERE](https://img.shields.io/badge/%F0%9F%87%B5%F0%9F%87%B8_YOUR_MESSAGE_HERE-techforpalestine.org-000?labelColor=grey&color=D83838&link=https%3A%2F%2Ftechforpalestine.org%2Flearn-more)


### PR DESCRIPTION
This PR also moves the flag in the code snippet to the same position as the one in the example image and adds a note about the `color` and `labelColor` parameters for users who would like to change these.